### PR TITLE
Make the search API tests pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "mime": "^1.2.11"
   },
   "devDependencies": {
-    "mocha": "~1.13.0"
+    "mocha": "~2.3.4",
+    "nock": "^5.2.1"
   },
   "main": ".",
   "scripts": {

--- a/test/searchTest.js
+++ b/test/searchTest.js
@@ -9,13 +9,12 @@
 
 "use strict";
 
-var Assert = require("assert");
 var Client = require("./../index");
-var testAuth = require("./../test_auth.json");
+var nock = require('nock');
 
 describe("[search]", function() {
     var client;
-    var token = testAuth["token"];
+    var token = "my test token";
 
     beforeEach(function() {
         client = new Client();
@@ -26,83 +25,97 @@ describe("[search]", function() {
     });
 
     it("should successfully execute GET /search/code (code)",  function(next) {
+        var expected = nock('https://api.github.com')
+            .get('/search/code')
+            .query({ access_token: token })
+            .query({ q: "my search", sort: "indexed", order: "asc", page: "2", per_page: "30" })
+            .reply();
+
         client.search.code(
             {
-                q: "String",
-                sort: "String",
-                order: "String",
-                page: "Number",
-                per_page: "Number"
-            },
-            function(err, res) {
-                Assert.equal(err, null);
-                // other assertions go here
-                next();
+                q: "my search",
+                sort: "indexed",
+                order: "asc",
+                page: 2,
+                per_page: 30
             }
         );
+        expected.done();
+        next();
     });
 
     it("should successfully execute GET /legacy/user/email/:email (email)",  function(next) {
+        var expected = nock('https://api.github.com')
+            .get('/legacy/user/email/my%40email.com')
+            .query({ access_token: token })
+            .reply();
+
         client.search.email(
             {
-                email: "String"
-            },
-            function(err, res) {
-                Assert.equal(err, null);
-                // other assertions go here
-                next();
+                email: "my@email.com"
             }
         );
+        expected.done();
+        next();
     });
 
     it("should successfully execute GET /search/issues (issues)",  function(next) {
+        var expected = nock('https://api.github.com')
+            .get('/search/issues')
+            .query({ access_token: token })
+            .query({ q: "my search", sort: "comments", order: "asc", page: "2", per_page: "30" })
+            .reply();
+
         client.search.issues(
             {
-                q: "String",
-                sort: "String",
-                order: "String",
-                page: "Number",
-                per_page: "Number"
-            },
-            function(err, res) {
-                Assert.equal(err, null);
-                // other assertions go here
-                next();
+                q: "my search",
+                sort: "comments",
+                order: "asc",
+                page: 2,
+                per_page: 30
             }
         );
+        expected.done();
+        next();
     });
 
     it("should successfully execute GET /search/repositories (repos)",  function(next) {
+        var expected = nock('https://api.github.com')
+            .get('/search/repositories')
+            .query({ access_token: token })
+            .query({ q: "my search", sort: "stars", order: "asc", page: "2", per_page: "30" })
+            .reply();
+
         client.search.repos(
             {
-                q: "String",
-                sort: "String",
-                order: "String",
-                page: "Number",
-                per_page: "Number"
-            },
-            function(err, res) {
-                Assert.equal(err, null);
-                // other assertions go here
-                next();
+                q: "my search",
+                sort: "stars",
+                order: "asc",
+                page: 2,
+                per_page: 30
             }
         );
+        expected.done();
+        next();
     });
 
     it("should successfully execute GET /search/users (users)",  function(next) {
+        var expected = nock('https://api.github.com')
+            .get('/search/users')
+            .query({ access_token: token })
+            .query({ q: "my search", sort: "followers", order: "asc", page: "2", per_page: "30" })
+            .reply();
+
         client.search.users(
             {
-                q: "String",
-                sort: "String",
-                order: "String",
-                page: "Number",
-                per_page: "Number"
-            },
-            function(err, res) {
-                Assert.equal(err, null);
-                // other assertions go here
-                next();
+                q: "my search",
+                sort: "followers",
+                order: "asc",
+                page: 2,
+                per_page: 30
             }
         );
+        expected.done();
+        next();
     });
 });


### PR DESCRIPTION
This PR fixes the tests of the search API. I've chosen this API simply because it's (almost) the smallest test file in the repo.

The point of this PR is to test the HTTP requests built by `node-github`. For this, I used `nock`, a HTTP mocking library.
I would have fixed more tests, but I preferred to gather feedback before doing so.

If you think this is the right way to go (and so do I), then we can start fixing the rest of the test suite and provide this library with the green badge it deserves :smile: .
