### PR TITLE
Correct entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "mocha": "~1.13.0"
   },
-  "main": ".",
+  "main": "lib",
   "scripts": {
     "test": "mocha"
   },


### PR DESCRIPTION
**github4 v0.5.2** causes `Error: Cannot find module 'github4'` by this change: 0d07c1b8ebde60213083a1a8877c715ff7c63d5f.
Need to update the entry point in the package.json.

Resolves #90.
