### PR TITLE
Add new function users.getById

### DIFF
--- a/doc/apidoc.js
+++ b/doc/apidoc.js
@@ -3683,6 +3683,17 @@ github.users.getAll({ ... });
  */
 
 /**
+ * @api {get} /user/:id getById
+ * @apiName getById
+ * @apiDescription Get a single user by GitHub ID
+ * @apiGroup users
+ *
+ * @apiParam {String} id  
+ * @apiExample {js} ex:
+github.users.getById({ ... });
+ */
+
+/**
  * @api {get} /user/emails getEmails
  * @apiName getEmails
  * @apiDescription List email addresses for a user

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -4683,6 +4683,15 @@
             "description": "Get a single user"
         },
 
+        "get-by-id": {
+            "url": "/user/:id",
+            "method": "GET",
+            "params": {
+                "$id": null
+            },
+            "description": "Get a single user by GitHub ID"
+        },
+
         "update": {
             "url": "/user",
             "method": "PATCH",

--- a/test/usersTest.js
+++ b/test/usersTest.js
@@ -165,6 +165,19 @@ describe("[users]", function() {
         );
     });
 
+    it("should successfully execute GET /user/:id (getById)",  function(next) {
+        client.users.getById(
+            {
+                id: "String"
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                // other assertions go here
+                next();
+            }
+        );
+    });
+
     it("should successfully execute GET /user/emails (getEmails)",  function(next) {
         client.users.getEmails(
             {


### PR DESCRIPTION
GitHub supports resolving user by github id.
There is this route https://api.github.com/user/429706 currently not in the documentation.
This route was available for over a year now and last time I talked to GitHub support they said that they have plans to include it in the documentation soon.
